### PR TITLE
add nodejs10 runtime

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ func isValidRuntime(r string) bool {
 	return map[string]bool{
 		"nodejs6":  true,
 		"nodejs8":  true,
+		"nodejs10":  true,
 		"python37": true,
 		"go111":    true,
 		"go113":    true,


### PR DESCRIPTION
Add support for nodejs10 runtime because the nodejs8 and nodejs6 runtimes are deprecated.

https://cloud.google.com/functions/docs/concepts/nodejs-10-runtime