### PR TITLE
Added go116 as a valid runtime

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,6 +77,7 @@ func isValidRuntime(r string) bool {
 		"python39": true,
 		"go111":    true,
 		"go113":    true,
+		"go116":    true,
 		"java11":   true,
 	}[r]
 }


### PR DESCRIPTION
Per GCP docs, golang runtime 1.16 is recommended ([ref](https://cloud.google.com/functions/docs/concepts/go-runtime))

This PR adds `go116` to a valid runtime