### PR TITLE
Allow preview runtime for go118 and go119

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,6 +84,8 @@ func isValidRuntime(r string) bool {
 		"go111":     true,
 		"go113":     true,
 		"go116":     true,
+		"go118":     true,
+		"go119":     true,
 		"java11":    true,
 		"java17":    true,
 		"dotnet3":   true,


### PR DESCRIPTION
GCF for Go allows to use go118 and go119 -> [ref](https://cloud.google.com/functions/docs/concepts/go-runtime)

This PR adds go118 and go119 as a valid runtime