### PR TITLE
Add Missing valid GCF Go Runtimes

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,6 +88,8 @@ func isValidRuntime(r string) bool {
 		"go116":     true,
 		"go118":     true,
 		"go119":     true,
+		"go120":     true,
+		"go121":     true,
 		"java11":    true,
 		"java17":    true,
 		"dotnet3":   true,


### PR DESCRIPTION
Add two missing Go runtimes:

* go120
* go121

Current valid runtimes are found documented here:
https://cloud.google.com/functions/docs/concepts/go-runtime

At the  time of this PR, 1.20 and 1.21 are missing from drone-gcf, and the plugin still accepts go111 which doesn't appear to be suppored by google any more.

I'll defer the removal of go111 because that has larger implications than just adding new valid runtimes :)