### PR TITLE
add nodejs18 and nodejs20 runtimes

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,6 +78,8 @@ func isValidRuntime(r string) bool {
 		"nodejs12":  true,
 		"nodejs14":  true,
 		"nodejs16":  true,
+		"nodejs18":  true,
+		"nodejs20":  true,
 		"python37":  true,
 		"python38":  true,
 		"python39":  true,


### PR DESCRIPTION
Co-Authored By: Michael Andre @mtandre

@oliver006 thanks for your work maintaining this package. We'd like to support Node18 and Node20 runtimes for Cloud Functions, as Node16 will be deprecated in GCP on Jan 30, 2024.