### PR TITLE
Retry function does not take params; should be bool

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ type Function struct {
 	EntryPoint           string `json:"entrypoint"`
 	Memory               string `json:"memory"`
 	Region               string `json:"region"`
-	Retry                string `json:"retry"`
+	Retry                bool   `json:"retry"`
 	Runtime              string `json:"runtime"`
 	Source               string `json:"source"`
 	Timeout              string `json:"timeout"`
@@ -354,8 +354,8 @@ func CreateExecutionPlan(cfg *Config) (Plan, error) {
 			if f.Region != "" {
 				args = append(args, "--region", f.Region)
 			}
-			if f.Retry != "" {
-				args = append(args, "--retry", f.Retry)
+			if f.Retry {
+				args = append(args, "--retry")
 			}
 			if f.Timeout != "" {
 				args = append(args, "--timeout", f.Timeout)

--- a/main_test.go
+++ b/main_test.go
@@ -268,7 +268,7 @@ func TestExecutePlan(t *testing.T) {
 						TriggerResource: "gs://bucket/files/cool",
 						Source:          "src/",
 						Region:          "us-east1",
-						Retry:           "3",
+						Retry:           true,
 					},
 					{
 						Name:            "ProcessMoreEvents",
@@ -293,7 +293,7 @@ func TestExecutePlan(t *testing.T) {
 				{"--quiet", "functions", "deploy", "--project", pId, "--verbosity", "info", "ProcessEvents", "--runtime", "go111", "--trigger-http", "--allow-unauthenticated", "--memory", "512MB", "--timeout", "20s"},
 				{"--quiet", "functions", "deploy", "--project", pId, "--verbosity", "info", "ProcessEvents", "--runtime", "go111", "--trigger-http", "--gen2", "--memory", "512MB", "--timeout", "20s"},
 				{"--quiet", "functions", "deploy", "--project", pId, "--verbosity", "info", "ProcessPubSub", "--runtime", "python37", "--trigger-topic", "topic/emails/filtered", "--memory", "2048MB", "--timeout", "20s"},
-				{"--quiet", "functions", "deploy", "--project", pId, "--verbosity", "info", "ProcessNews", "--runtime", "go111", "--trigger-bucket", "gs://bucket/files/cool", "--source", "src/", "--region", "us-east1", "--retry", "3"},
+				{"--quiet", "functions", "deploy", "--project", pId, "--verbosity", "info", "ProcessNews", "--runtime", "go111", "--trigger-bucket", "gs://bucket/files/cool", "--source", "src/", "--region", "us-east1", "--retry"},
 				{"--quiet", "functions", "deploy", "--project", pId, "--verbosity", "info", "ProcessMoreEvents", "--runtime", "go111", "--trigger-event", "my.event", "--trigger-resource=my.trigger.resource", "--entry-point", "FuncEntryPoint"},
 				{"--quiet", "functions", "deploy", "--project", pId, "--verbosity", "info", "ProcessEventsWithDifferentSA", "--runtime", "nodejs10", "--trigger-http", "--memory", "512MB", "--timeout", "20s", "--service-account", "account@project.iam.gserviceaccount.com"},
 			},


### PR DESCRIPTION
The Google Cloud Function parameter `--retry` does not take parameters.

For this config...

```
<TRUNCATED>
steps:
  - name: deploy-cf-northamerica-northeast1
    image: oliver006/drone-gcf:latest
    settings:
      action: deploy
      project: *project
      verbose: true
      runtime: *runtime
      token:
        from_secret: MY_DEPLOYMENT_KEY
      functions:
        - my-functions-name:
          - gen2: true
            retry: "3"
            trigger: topic
            trigger_resource: gcr
<TRUNCATED>
```

Attempting to use retry with this drone plugin returns the following error:

```
latest: Pulling from oliver006/drone-gcf
Digest: sha256:d1b35ab6d3f739d5d59d5c7d4f291135eacfc993a3defe1f26eee9a98e185718
Status: Downloaded newer image for oliver006/drone-gcf:latest
2023/12/11 16:16:56 Drone-GCF Plugin  version: v1.24.0   hash: 652c0fe5df9d7a0dc0e67dee67d53dc25027f5d7   date: 2023-11-24-04:29:44
2023/12/11 16:16:56 Using project ID: my-project
Google Cloud SDK 422.0.0
alpha 2023.03.10
beta 2023.03.10
bq 2.0.88
bundled-python3-unix 3.9.16
core 2023.03.10
gcloud-crc32c 1.0.0
gsutil 5.21
Activated service account credentials for: [my-runner@my-project.iam.gserviceaccount.com]
ERROR: (gcloud.functions.deploy) unrecognized arguments: 3

To search the help text of gcloud commands, run:
  gcloud help -- SEARCH_TERMS
2023/12/11 16:16:59 runConfig() err: error: exit status 2
```

The current state of drone-gcf implies that we can specify the number of retry attempts to be made, which does not seem to be a part of the GCF spec.

Since this module actually invokes the `gcloud function deploy` command, the `--retry` argument in that command is undecorated with a param: https://cloud.google.com/sdk/gcloud/reference/functions/deploy#--retry

The situation is subtly different for [gen2 API
structure](https://cloud.google.com/functions/docs/reference/rest/v2/projects.locations.functions#RetryPolicy), but since everything is mediated by gcloud anyway, we definitly do not seem to be able to declare things like "Please retry up to 3 times".

Using retries in GCF are more complicated, in that the developer must manage retrying within code, typically paying attention to the submission time of the event that triggered execution and declaring an absolute cutoff date to stop retrying.

[Enable event-driven function retries](https://cloud.google.com/functions/docs/bestpractices/retries)

The dev becomes responsible for managing infinate looping and differentiating between retryable failures and actual fatal ones.

My kingdom for a nice little integer to say "retry three times pls, kaytnxbai!" but that seems to be far too optimistic for GCF.